### PR TITLE
🩹 [Patch]: Remove 'All' test

### DIFF
--- a/tests/GoogleFonts.Tests.ps1
+++ b/tests/GoogleFonts.Tests.ps1
@@ -18,10 +18,5 @@
             { Install-GoogleFont -Name 'Akshar' } | Should -Not -Throw
             Get-Font -Name 'Akshar*' | Should -Not -BeNullOrEmpty
         }
-
-        It '[Install-GoogleFont] - Installs all fonts' {
-            { Install-GoogleFont -All -Verbose } | Should -Not -Throw
-            Get-Font -Name 'Nabla*' | Should -Not -BeNullOrEmpty
-        }
     }
 }


### PR DESCRIPTION
## Description

This pull request includes a small change to the `tests/GoogleFonts.Tests.ps1` file. The change removes a test case that verified the installation of all fonts using the `Install-GoogleFont -All -Verbose` command. The test takes somewhere between 5-6 hours on ubuntu runners.

Test case removal:

* [`tests/GoogleFonts.Tests.ps1`](diffhunk://#diff-30eb66e3d9c181760a2592b5d8f167e0cd3f734b5f5562a1aac43e11c862e124L21-L25): Removed the test case that installed **all** fonts and checked for the presence of the 'Nabla' font.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
