### PR TITLE
🩹 [Patch]: Update FontsUpdater to use separate credentials

### DIFF
--- a/.github/workflows/Update-FontsData.yml
+++ b/.github/workflows/Update-FontsData.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Update-FontsData
         uses: PSModule/GitHub-Script@v1

--- a/scripts/Update-FontsData.ps1
+++ b/scripts/Update-FontsData.ps1
@@ -1,4 +1,4 @@
-﻿Connect-GitHubApp -Organization PSModule
+﻿Connect-GitHubApp -Organization PSModule -Default
 
 git checkout main
 git pull

--- a/src/FontsData.json
+++ b/src/FontsData.json
@@ -1,35 +1,5 @@
 [
   {
-    "Name": "42dot Sans",
-    "Variant": "300",
-    "URL": "https://fonts.gstatic.com/s/42dotsans/v1/BXR7vFK-2v7FnQ1xTYUJy2T9rRBKbpqjqRiHYkNScXgiTCI-.ttf"
-  },
-  {
-    "Name": "42dot Sans",
-    "Variant": "regular",
-    "URL": "https://fonts.gstatic.com/s/42dotsans/v1/BXR7vFK-2v7FnQ1xTYUJy2T9rRBKbpqjqRjZYkNScXgiTCI-.ttf"
-  },
-  {
-    "Name": "42dot Sans",
-    "Variant": "500",
-    "URL": "https://fonts.gstatic.com/s/42dotsans/v1/BXR7vFK-2v7FnQ1xTYUJy2T9rRBKbpqjqRjrYkNScXgiTCI-.ttf"
-  },
-  {
-    "Name": "42dot Sans",
-    "Variant": "600",
-    "URL": "https://fonts.gstatic.com/s/42dotsans/v1/BXR7vFK-2v7FnQ1xTYUJy2T9rRBKbpqjqRgHZUNScXgiTCI-.ttf"
-  },
-  {
-    "Name": "42dot Sans",
-    "Variant": "700",
-    "URL": "https://fonts.gstatic.com/s/42dotsans/v1/BXR7vFK-2v7FnQ1xTYUJy2T9rRBKbpqjqRg-ZUNScXgiTCI-.ttf"
-  },
-  {
-    "Name": "42dot Sans",
-    "Variant": "800",
-    "URL": "https://fonts.gstatic.com/s/42dotsans/v1/BXR7vFK-2v7FnQ1xTYUJy2T9rRBKbpqjqRhZZUNScXgiTCI-.ttf"
-  },
-  {
     "Name": "ABeeZee",
     "Variant": "regular",
     "URL": "https://fonts.gstatic.com/s/abeezee/v22/esDR31xSG-6AGleN6tKukbcHCpE.ttf"


### PR DESCRIPTION
## Description

This pull request includes updates to the `Update-FontsData` workflow and script to enhance security and ensure proper connection defaults.

Workflow updates:

* [`.github/workflows/Update-FontsData.yml`](diffhunk://#diff-5c6d6ac6744e613c22fe7a4b5bf6b9fbd4b3bf5548239191e4400a4b17440826R17-R18): Added `persist-credentials: false` to the `actions/checkout` step to enhance security by not persisting GitHub credentials.

Script updates:

* [`scripts/Update-FontsData.ps1`](diffhunk://#diff-69d235ffacf154789a70d5e00a557ee83393c256cd9431a8b7be57cc41c3ad89L1-R1): Modified the `Connect-GitHubApp` command to include the `-Default` parameter, ensuring the default connection settings are used.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
