### PR TITLE
🩹 [Patch]: Light support for PS 5.1

### DIFF
--- a/src/classes/private/Scope.ps1
+++ b/src/classes/private/Scope.ps1
@@ -1,4 +1,0 @@
-﻿enum Scope {
-    CurrentUser
-    AllUsers
-}

--- a/src/functions/public/Install-GoogleFont.ps1
+++ b/src/functions/public/Install-GoogleFont.ps1
@@ -53,7 +53,8 @@ function Install-GoogleFont {
 
         # Specify the scope of where to install the font(s).
         [Parameter()]
-        [Scope] $Scope = 'CurrentUser',
+        [ValidateSet('CurrentUser', 'AllUsers')]
+        [string] $Scope = 'CurrentUser',
 
         # Force will overwrite existing fonts
         [Parameter()]

--- a/src/functions/public/Install-GoogleFont.ps1
+++ b/src/functions/public/Install-GoogleFont.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Fonts'; RequiredVersion = '1.1.13' }
+﻿#Requires -Modules @{ ModuleName = 'Fonts'; RequiredVersion = '1.1.18' }
 
 function Install-GoogleFont {
     <#

--- a/src/manifest.psd1
+++ b/src/manifest.psd1
@@ -1,0 +1,3 @@
+﻿@{
+    PowerShellVersion = '5.1'
+}


### PR DESCRIPTION
## Description

This pull request includes changes to the `src/classes/private/Scope.ps1`, `src/functions/public/Install-GoogleFont.ps1`, and `src/manifest.psd1` files. The most important changes involve the removal of the `Scope` enum, updating module requirements, and modifying parameter validation.

Parameter validation and module updates:

* [`src/functions/public/Install-GoogleFont.ps1`](diffhunk://#diff-f926b03377b12f05eed72cf360452ff4ac9b8f4a2c7c858e02068ea43cc050a5L1-R1): Updated the required version of the `Fonts` module from '1.1.13' to '1.1.18'.
* [`src/functions/public/Install-GoogleFont.ps1`](diffhunk://#diff-f926b03377b12f05eed72cf360452ff4ac9b8f4a2c7c858e02068ea43cc050a5L56-R57): Replaced the `Scope` enum with a `ValidateSet` for the `$Scope` parameter, ensuring it can only be 'CurrentUser' or 'AllUsers'.

Code simplification:

* [`src/classes/private/Scope.ps1`](diffhunk://#diff-9f8b649c9594a7c7582dae3baf1841e8ffa82e1cbb7e1fae8b560b56f141e6f1L1-L4): Removed the `Scope` enum.

Manifest updates:

* [`src/manifest.psd1`](diffhunk://#diff-89820c99acb3b881e314c7e358eea621a8687cb4e0c687f541b9dcc9f30cc5dcR1-R3): Added a manifest file specifying `PowerShellVersion` as '5.1'.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
