### PR TITLE
🩹 [Patch]: Add linter environment variables for validation checks

### DIFF
--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -19,3 +19,12 @@ Test:
 # Build:
 #   Docs:
 #     Skip: true
+Linter:
+  env:
+    VALIDATE_BIOME_FORMAT: false
+    VALIDATE_BIOME_LINT: false
+    VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+    VALIDATE_JSCPD: false
+    VALIDATE_JSON_PRETTIER: false
+    VALIDATE_MARKDOWN_PRETTIER: false
+    VALIDATE_YAML_PRETTIER: false


### PR DESCRIPTION
## Description

This pull request adds configuration to the `.github/PSModule.yml` file to adjust the linter environment settings. The main change is the explicit disabling of several linter validations by setting their environment variables to `false`.

Linter configuration updates:

* Disabled specific linter validations by setting the following environment variables to `false`: `VALIDATE_BIOME_FORMAT`, `VALIDATE_BIOME_LINT`, `VALIDATE_GITHUB_ACTIONS_ZIZMOR`, `VALIDATE_JSCPD`, `VALIDATE_JSON_PRETTIER`, `VALIDATE_MARKDOWN_PRETTIER`, and `VALIDATE_YAML_PRETTIER` in `.github/PSModule.yml`
