### PR TITLE
🪲 [Fix]: Fix linter settings and docs

### DIFF
--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -19,6 +19,7 @@ Test:
 # Build:
 #   Docs:
 #     Skip: true
+
 Linter:
   env:
     VALIDATE_BIOME_FORMAT: false


### PR DESCRIPTION
## Description

This pull request makes a minor update to the `.github/PSModule.yml` configuration file, specifically related to the linter environment settings. The change disables the `VALIDATE_BIOME_FORMAT` check for the linter.

* [`.github/PSModule.yml`](diffhunk://#diff-928165ed381f1982eb8f9746a59a2829db4abc8a28eddb8c109e12bb033ff96aR22): Set `VALIDATE_BIOME_FORMAT` to `false` in the linter environment configuration.