### PR TITLE
🩹 [Patch]: Pin action versions and fix dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,6 @@ updates:
       - dependencies
       - github-actions
     schedule:
-      interval: weekly
+      interval: daily
+    cooldown:
+      default-days: 7

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -27,5 +27,5 @@ permissions:
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v5
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@be7d5dcbceec14855d325fdd34f2a7c2f05a7f57 # v5.4.1
     secrets: inherit

--- a/.github/workflows/Update-FontsData.yml
+++ b/.github/workflows/Update-FontsData.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Update-FontsData
-        uses: PSModule/GitHub-Script@v1
+        uses: PSModule/GitHub-Script@2010983167dc7a41bcd84cb88e698ec18eccb7ca # v1.7.8
         env:
           GOOGLE_DEVELOPER_API_KEY: ${{ secrets.GOOGLE_DEVELOPER_API_KEY }}
         with:


### PR DESCRIPTION
All GitHub Actions are now pinned to specific SHA versions for improved security and consistency. The dependabot configuration has been updated to use daily checks with a 7-day cooldown period.

- Fixes #128

## Pin action versions to SHA

The following actions have been pinned to specific SHA versions:

- `actions/checkout` → `8e8c483db84b4bee98b60c0593521ed34d9990e8` (v6.0.1)
- `PSModule/GitHub-Script` → `2010983167dc7a41bcd84cb88e698ec18eccb7ca` (v1.7.8)
- `PSModule/Process-PSModule` → `be7d5dcbceec14855d325fdd34f2a7c2f05a7f57` (v5.4.1)

## Fix dependabot configuration

The dependabot.yml has been updated to align with the standard configuration:

- Changed `schedule.interval` from `weekly` to `daily`
- Added `cooldown.default-days: 7` to delay updates for 7 days after release

This ensures Dependabot checks for updates daily but waits 7 days before creating PRs, giving time for any issues with new releases to surface.