### PR TITLE
⚙️ [Maintenance]: Fix Update-FontsData script: gh CLI json args and hardcoded repo name

### DIFF
--- a/scripts/Update-FontsData.ps1
+++ b/scripts/Update-FontsData.ps1
@@ -33,6 +33,8 @@
     }
 }
 
+$repoName = $env:GITHUB_REPOSITORY
+
 Install-PSResource -Repository PSGallery -TrustRepository -Name 'Json'
 
 Connect-GitHubApp -Organization 'PSModule' -Default
@@ -143,7 +145,7 @@ LogGroup 'Process changes' {
                 if ($retryCount -gt 0) {
                     Start-Sleep -Seconds $retryDelays[$retryCount - 1]
                 }
-                $newPRJson = Run gh pr list --repo 'PSModule/GoogleFonts' --head $targetBranch --state open --json number, title --limit 1
+                $newPRJson = Run gh pr list --repo $repoName --head $targetBranch --state open --json 'number,title' --limit 1
                 $newPR = $newPRJson | ConvertFrom-Json | Select-Object -First 1
                 if ($null -eq $newPR -or $null -eq $newPR.number) {
                     $newPR = $null
@@ -159,7 +161,7 @@ LogGroup 'Process changes' {
                 Write-Output "Found new PR #$($newPR.number): $($newPR.title)"
 
                 # Find existing open Auto-Update PRs (excluding the one we just created)
-                $existingPRsJson = Run gh pr list --repo 'PSModule/GoogleFonts' --state open --search 'Auto-Update in:title' --json number, title
+                $existingPRsJson = Run gh pr list --repo $repoName --state open --search 'Auto-Update in:title' --json 'number,title'
                 $existingPRs = $existingPRsJson | ConvertFrom-Json | Where-Object { $_.number -ne $newPR.number }
 
                 if ($existingPRs) {
@@ -173,10 +175,10 @@ This PR has been superseded by #$($newPR.number) and will be closed automaticall
 
 The font data has been updated in the newer PR. Please refer to #$($newPR.number) for the most current changes.
 "@
-                        Run gh pr comment $pr.number --repo 'PSModule/GoogleFonts' --body $comment
+                        Run gh pr comment $pr.number --repo $repoName --body $comment
 
                         # Close the PR
-                        Run h pr close $pr.number --repo 'PSModule/GoogleFonts'
+                        Run gh pr close $pr.number --repo $repoName
 
                         Write-Output "Successfully closed PR #$($pr.number)"
                     }


### PR DESCRIPTION
The Update-FontsData workflow script now correctly passes arguments to the `gh` CLI and uses the `GITHUB_REPOSITORY` environment variable instead of a hardcoded repository name, making the script portable and fixing the workflow failure.

- Fixes #151

## Fix `--json` argument parsing

The `--json number, title` argument was split by PowerShell into two separate arguments (`number,` and `title`), causing `gh` CLI to report `Unknown JSON field: "number title"`. The argument is now quoted as `'number,title'` to ensure it is passed as a single value.

## Replace hardcoded repository name with variable

All four occurrences of the hardcoded `'PSModule/GoogleFonts'` repo name in `gh` CLI calls have been replaced with a `$repoName` variable, set from `$env:GITHUB_REPOSITORY`. This makes the script work correctly in any fork or renamed repository without code changes.

## Fix `gh` CLI typo

A typo in the PR close command (`Run h pr close` instead of `Run gh pr close`) has been corrected.