### PR TITLE
📖 [Docs]: Update scripts README documentation

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,7 +4,8 @@ This directory contains scripts for automating the maintenance of the GoogleFont
 
 ## Update-FontsData.ps1
 
-This script automatically updates the `src/FontsData.json` file with the latest font metadata from Google Fonts API.
+This script automatically updates the `src/FontsData.json` file with the latest font metadata from
+Google Fonts API.
 
 ### Features
 
@@ -24,6 +25,7 @@ This script automatically updates the `src/FontsData.json` file with the latest 
 5. **PR Supersedence**: After creating a new PR, the script:
    - Searches for existing open PRs with titles matching `Auto-Update*` (excluding the newly created PR)
    - Closes each superseded PR with a comment referencing the new PR number
+   - Deletes the branches associated with superseded PRs
    - Ensures only the latest update PR remains open
 
 ### PR Lifecycle Management
@@ -33,20 +35,25 @@ The font data updater implements PR supersedence similar to Dependabot. When a n
 - The script first creates the new PR
 - Then checks for existing open `Auto-Update*` PRs (excluding the newly created one)
 - Each existing PR receives a comment referencing the new PR number:
+
   ```text
   This PR has been superseded by #[NEW_PR_NUMBER] and will be closed automatically.
 
   The font data has been updated in the newer PR. Please refer to #[NEW_PR_NUMBER] for the most current changes.
   ```
-- All superseded PRs are automatically closed
 
-This means there is no need for a separate cleanup workflow on merge — by the time a PR is merged, it is already the only open Auto-Update PR.
+- All superseded PRs are automatically closed
+- Branches for closed PRs are deleted
+
+This means there is no need for a separate cleanup workflow on merge — by the time a PR is merged,
+it is already the only open Auto-Update PR.
 
 ### Workflow
 
 #### Update-FontsData.yml
 
 Handles the scheduled updates, PR creation, and supersedence:
+
 - **Trigger**: Daily at midnight UTC, or manual via `workflow_dispatch`
 - **Authentication**: Uses GitHub App credentials for API access
 - **Permissions**: Requires secrets:
@@ -65,8 +72,8 @@ You can manually trigger an update using the GitHub Actions UI:
 
 ### Configuration
 
-The supersedence behavior is built into the script and requires no additional configuration. The message posted when closing superseded PRs can be
-customized by modifying `scripts/Update-FontsData.ps1`.
+The supersedence behavior is built into the script and requires no additional configuration. The message
+posted when closing superseded PRs can be customized by modifying `scripts/Update-FontsData.ps1`.
 
 ### Development
 
@@ -76,7 +83,8 @@ To test changes to the update script:
 2. Modify `scripts/Update-FontsData.ps1`
 3. Push the branch
 4. Manually trigger the workflow on your feature branch
-5. The script will detect it's running on a feature branch and update the existing branch instead of creating a new PR
+5. The script will detect it's running on a feature branch and update the existing branch instead of
+   creating a new PR
 
 ### Troubleshooting
 


### PR DESCRIPTION
Updates the scripts README with improved accuracy, missing details, and markdown style consistency. The documentation now fully reflects the current behavior of the font data updater, including branch cleanup for superseded PRs.

- Fixes #158

## Branch cleanup documentation

Added missing documentation about branch deletion for superseded PRs. The `Update-FontsData.ps1` script deletes branches associated with closed superseded PRs, which was previously undocumented.

## Markdown style fixes

- Fixed line wrapping to comply with the 80-120 character guideline
- Added blank lines before and after fenced code blocks per markdown conventions
- Improved readability of long paragraphs by breaking at natural phrase boundaries
