### PR TITLE
📖 [Docs]: README pages now use the standard module landing-page format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # GoogleFonts
 
-GoogleFonts is a PowerShell module for downloading and installing fonts from Google Fonts.
+GoogleFonts is a PowerShell module for downloading and installing fonts from Google Fonts. The module does not
+ship the fonts themselves; it fetches them from the [google/fonts](https://github.com/google/fonts) repository and
+installs them on your system.
 
 ## Prerequisites
 
@@ -15,6 +17,39 @@ Install-PSResource -Name GoogleFonts
 Import-Module -Name GoogleFonts
 ```
 
+## Usage
+
+### List available fonts
+
+List the fonts available from Google Fonts. Filter by name with wildcards:
+
+```powershell
+Get-GoogleFont
+Get-GoogleFont -Name 'Noto*'
+```
+
+### Install a font
+
+Install a font for the current user. Name tab-completion is supported:
+
+```powershell
+Install-GoogleFont -Name 'Roboto'
+```
+
+Install a font for all users. This requires an elevated session (sudo or run as administrator):
+
+```powershell
+Install-GoogleFont -Name 'Roboto' -Scope AllUsers
+```
+
+### Install every font
+
+Download and install all Google Fonts for the current user:
+
+```powershell
+Install-GoogleFont -All
+```
+
 ## Documentation
 
 Documentation is published at [psmodule.io/GoogleFonts](https://psmodule.io/GoogleFonts/).
@@ -26,6 +61,7 @@ Get-Command -Module GoogleFonts
 Get-Help Install-GoogleFont -Examples
 ```
 
-## Contributing
+## Related links
 
-Issues and pull requests are welcome. Please use the repository issue tracker to report bugs, request features, or discuss improvements.
+- [google/fonts on GitHub](https://github.com/google/fonts)
+- [Google Fonts](https://fonts.google.com/)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GoogleFonts is a PowerShell module for downloading and installing fonts from Goo
 
 ## Prerequisites
 
-`Install-GoogleFont` requires the `Fonts` module version 1.1.21 or later and the `Admin` module version 1.1.6 or later.
+`Install-GoogleFont` requires the `Fonts` module version 1.1.21 and the `Admin` module version 1.1.6.
 
 ## Installation
 
@@ -23,7 +23,7 @@ Use PowerShell help and command discovery for module details:
 
 ```powershell
 Get-Command -Module GoogleFonts
-Get-Help <CommandName> -Examples
+Get-Help Install-GoogleFont -Examples
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,71 +1,27 @@
 # GoogleFonts
 
-This is a PowerShell module for installing GoogleFonts on your system. This module and repository does not contain the fonts themselves,
-but rather a way to install them on your system.
-
-🎉 Kudos to the GoogleFonts community for keeping the library going! 🎉
-For any issues with the fonts themselves, please refer to the [GoogleFonts](https://github.com/google/fonts) repository.
-
-## Prerequisites
-
-This module depends on the [Fonts](https://psmodule.io/Fonts) module to manage fonts on the system.
+GoogleFonts is a PowerShell module for downloading and installing fonts from Google Fonts.
 
 ## Installation
 
-To install the module simply run the following command in a PowerShell terminal.
+Install the module from the PowerShell Gallery:
 
 ```powershell
 Install-PSResource -Name GoogleFonts
 Import-Module -Name GoogleFonts
 ```
 
-## Usage
+## Documentation
 
-### Install a GoogleFont
+Documentation is published at [psmodule.io/GoogleFonts](https://psmodule.io/GoogleFonts/).
 
-To install a GoogleFont on the system you can use the following command.
-
-```powershell
-Install-GoogleFont -Name 'Roboto' # Tab completion works on name
-```
-
-To download the font from the GoogleFonts repository and install it on the system, run the following command.
+Use PowerShell help and command discovery for module details:
 
 ```powershell
-Install-GoogleFont -Name 'Roboto' -Scope AllUsers #Tab completion works on Scope too
-```
-
-### Install all GoogleFonts
-
-To install all GoogleFonts on the system you can use the following command.
-
-This will download and install all GoogleFonts to the current user.
-```powershell
-Install-GoogleFont -All
-```
-
-To install all GoogleFonts on the system for all users, run the following command.
-This requires the shell to run in an elevated context (sudo or run as administrator).
-
-```powershell
-Install-GoogleFont -All -Scope AllUsers
+Get-Command -Module GoogleFonts
+Get-Help <CommandName> -Examples
 ```
 
 ## Contributing
 
-Coder or not, you can contribute to the project! We welcome all contributions.
-
-### For Users
-
-If you don't code, you still sit on valuable information that can make this project even better. If you experience that the
-product does unexpected things, throw errors or is missing functionality, you can help by submitting bugs and feature requests.
-Please see the issues tab on this project and submit a new issue that matches your needs.
-
-### For Developers
-
-If you do code, we'd love to have your contributions. Please read the [Contribution guidelines](CONTRIBUTING.md) for more information.
-You can either help by picking up an existing issue or submit a new one if you have an idea for a new feature or improvement.
-
-## Links
-
-- GoogleFonts | [GitHub](https://github.com/google/fonts) | [Web](https://fonts.google.com/)
+Issues and pull requests are welcome. Please use the repository issue tracker to report bugs, request features, or discuss improvements.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 GoogleFonts is a PowerShell module for downloading and installing fonts from Google Fonts.
 
+## Prerequisites
+
+`Install-GoogleFont` requires the `Fonts` module version 1.1.21 or later and the `Admin` module version 1.1.6 or later.
+
 ## Installation
 
 Install the module from the PowerShell Gallery:


### PR DESCRIPTION
The GoogleFonts README is now a concise landing page. Users get a short overview, prerequisites, install commands, real usage examples for the module's actual commands, and pointers to the published documentation — without scrolling through duplicated command reference content.

## What changed

- Restored a `## Usage` showcase using the real commands `Get-GoogleFont` (list/filter fonts) and `Install-GoogleFont` (`-Name`, `-Scope AllUsers`, `-All`).
- Kept the `## Prerequisites` note (`Fonts` and `Admin` module requirements).
- Installation uses `Install-PSResource`.
- `## Documentation` points to [psmodule.io/GoogleFonts](https://psmodule.io/GoogleFonts/) with a real `Get-Help Install-GoogleFont -Examples` discovery snippet.
- Restored the upstream links (`google/fonts` on GitHub, Google Fonts site) under `## Related links`.
- Removed the `## Contributing` section per the new module-README standard.

## Technical details

- Updates `README.md` only.
- Aligns the README with the PSModule module landing-page standard.